### PR TITLE
Contain project in ProjectName\romfs instead of ProjectName (Easier TKMM workflow)

### DIFF
--- a/src/file/game/texture/TexToGoFile.cpp
+++ b/src/file/game/texture/TexToGoFile.cpp
@@ -79,7 +79,7 @@ namespace application::file::game::texture
 				return false;
 			}
 
-			const astcenc_error ContextStatus = astcenc_context_alloc(&Config, 1, &Context);
+			const astcenc_error ContextStatus = astcenc_context_alloc(&Config, 1, &Context, nullptr);
 			if (ContextStatus != ASTCENC_SUCCESS || Context == nullptr)
 			{
 				application::util::Logger::Error("TexToGoFile", "ASTC context allocation failed for %s", FileName.c_str());

--- a/src/manager/ProjectMgr.cpp
+++ b/src/manager/ProjectMgr.cpp
@@ -37,7 +37,7 @@ namespace application::manager
 		if (std::find(gProjects.begin(), gProjects.end(), Name) != gProjects.end())
 			return;
 
-		std::filesystem::create_directory(application::util::FileUtil::GetWorkingDirFilePath("Projects/" + Name));
+		std::filesystem::create_directories(application::util::FileUtil::GetWorkingDirFilePath("Projects/" + Name + "/romfs"));
 
 		gProjects.push_back(Name);
 		SelectProject(Name);

--- a/src/util/FileUtil.cpp
+++ b/src/util/FileUtil.cpp
@@ -24,7 +24,7 @@ namespace application::util
 	{
 		if (Replaceable && application::manager::ProjectMgr::IsAnyProjectSelected())
 		{
-			const std::string ReplaceablePath = gCurrentDirectory + "/WorkingDir/Projects/" + application::manager::ProjectMgr::gProject + "/" + LocalPath;
+			const std::string ReplaceablePath = gCurrentDirectory + "/WorkingDir/Projects/" + application::manager::ProjectMgr::gProject + "/romfs/" + LocalPath;
 			if (FileExists(ReplaceablePath))
 				return ReplaceablePath;
 		}
@@ -34,7 +34,7 @@ namespace application::util
 
 	std::string FileUtil::GetBfresFilePath(const std::string& Name)
 	{
-		const std::string ReplaceablePath = gCurrentDirectory + "/WorkingDir/Projects/" + application::manager::ProjectMgr::gProject + "/Model/" + Name + ".mc";
+		const std::string ReplaceablePath = gCurrentDirectory + "/WorkingDir/Projects/" + application::manager::ProjectMgr::gProject + "/romfs/Model/" + Name + ".mc";
 		if (FileExists(ReplaceablePath))
 			return ReplaceablePath;
 
@@ -56,10 +56,10 @@ namespace application::util
 		if (!application::manager::ProjectMgr::IsAnyProjectSelected())
 			application::util::Logger::Error("FileUtil", "Tried to get save file path for %s while no project was selected", Path.c_str());
 
-		if(Path.empty())
-			return gCurrentDirectory + "/WorkingDir/Projects/" + application::manager::ProjectMgr::gProject;
+		if (Path.empty())
+			return gCurrentDirectory + "/WorkingDir/Projects/" + application::manager::ProjectMgr::gProject + "/romfs";
 
-		return gCurrentDirectory + "/WorkingDir/Projects/" + application::manager::ProjectMgr::gProject + "/" + Path;
+		return gCurrentDirectory + "/WorkingDir/Projects/" + application::manager::ProjectMgr::gProject + "/romfs/" + Path;
 	}
 
 	bool FileUtil::FileExists(const std::string& Path)


### PR DESCRIPTION
VS pointed out an error when building in `src/file/game/texture/TexToGoFile.cpp`, so I fixed that and now the release version builds. Additionally, to improve the Starlight-TKMM workflow, I've made modifications to how projects are saved to include a `\romfs` folder within `WorkingDir\Projects\ProjectName`, so the project can be used as the source folder for a TKMM project. 

**Note that users will need to move existing projects into a romfs folder, as I could not figure out how to add migration logic.**